### PR TITLE
Add is_allowed_to_start method

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Provided through [Tailwind CSS IntelliSense](https://github.com/tailwindlabs/tai
 ### Installation
 
 * Install [LSP](https://packagecontrol.io/packages/LSP) and `LSP-tailwindcss` via Package Control.
+* In order for the extension to activate you must have [tailwindcss](https://tailwindcss.com/docs/installation) installed and a [Tailwind config file](https://tailwindcss.com/docs/installation#create-your-configuration-file) named `tailwind.config.js` in your workspace.
 * Restart Sublime.
 
 ### Configuration

--- a/plugin.py
+++ b/plugin.py
@@ -1,4 +1,8 @@
 import os
+import sublime
+from LSP.plugin import ClientConfig
+from LSP.plugin import WorkspaceFolder
+from LSP.plugin.core.typing import List, Optional
 from lsp_utils import NpmClientHandler
 
 
@@ -16,6 +20,25 @@ class LspTailwindcssPlugin(NpmClientHandler):
     server_binary_path = os.path.join(
         server_directory, 'extension', 'dist', 'server', 'index.js'
     )
+
+    @classmethod
+    def is_allowed_to_start(
+        cls,
+        _window: sublime.Window,
+        _initiating_view: Optional[sublime.View] = None,
+        workspace_folders: Optional[List[WorkspaceFolder]] = None,
+        _configuration: Optional[ClientConfig] = None
+    ) -> Optional[str]:
+        if not workspace_folders:
+            return "{} - requires a folder to start.".format(cls.package_name)
+        path = workspace_folders[0].path
+        tailwind_config_file_path = os.path.join(path, 'tailwind.config.js')
+        if not os.path.exists(tailwind_config_file_path):
+            return "{} - no tailwind.config.js present in {}".format(cls.package_name, path)
+        is_tailwind_dependecy_installed = os.path.join(path, 'node_modules', 'tailwindcss')
+        if not os.path.exists(is_tailwind_dependecy_installed):
+            return "{} - No tailwindcss package found in node_modules for path {}. Make sure to install the tailwindcss npm package.".format(cls.package_name, path)
+        return None
 
     @classmethod
     def on_client_configuration_ready(cls, configuration: dict) -> None:

--- a/plugin.py
+++ b/plugin.py
@@ -24,10 +24,10 @@ class LspTailwindcssPlugin(NpmClientHandler):
     @classmethod
     def is_allowed_to_start(
         cls,
-        _window: sublime.Window,
-        _initiating_view: Optional[sublime.View] = None,
+        window: sublime.Window,
+        initiating_view: Optional[sublime.View] = None,
         workspace_folders: Optional[List[WorkspaceFolder]] = None,
-        _configuration: Optional[ClientConfig] = None
+        configuration: Optional[ClientConfig] = None
     ) -> Optional[str]:
         if not workspace_folders:
             return "Requires a folder to start."

--- a/plugin.py
+++ b/plugin.py
@@ -35,9 +35,6 @@ class LspTailwindcssPlugin(NpmClientHandler):
         tailwind_config_file_path = os.path.join(path, 'tailwind.config.js')
         if not os.path.exists(tailwind_config_file_path):
             return "No tailwind.config.js present in {}".format(path)
-        is_tailwind_dependecy_installed = os.path.join(path, 'node_modules', 'tailwindcss')
-        if not os.path.exists(is_tailwind_dependecy_installed):
-            return "No tailwindcss package found in node_modules for path {}. Make sure to install the tailwindcss npm package.".format(path)
         return None
 
     @classmethod

--- a/plugin.py
+++ b/plugin.py
@@ -30,14 +30,14 @@ class LspTailwindcssPlugin(NpmClientHandler):
         _configuration: Optional[ClientConfig] = None
     ) -> Optional[str]:
         if not workspace_folders:
-            return "{} - requires a folder to start.".format(cls.package_name)
+            return "Requires a folder to start."
         path = workspace_folders[0].path
         tailwind_config_file_path = os.path.join(path, 'tailwind.config.js')
         if not os.path.exists(tailwind_config_file_path):
-            return "{} - no tailwind.config.js present in {}".format(cls.package_name, path)
+            return "No tailwind.config.js present in {}".format(path)
         is_tailwind_dependecy_installed = os.path.join(path, 'node_modules', 'tailwindcss')
         if not os.path.exists(is_tailwind_dependecy_installed):
-            return "{} - No tailwindcss package found in node_modules for path {}. Make sure to install the tailwindcss npm package.".format(cls.package_name, path)
+            return "No tailwindcss package found in node_modules for path {}. Make sure to install the tailwindcss npm package.".format(path)
         return None
 
     @classmethod


### PR DESCRIPTION
Thanks guys for the tips that you left in the previous PR.

Start the server only if the tailwind.config.js is present
and if the user has tailwind css installed in node_modules.

How to test.
1. Create a `index.js` file.
2. Open it and you should see an error message printed - `LSP-tailwindcss - no tailwind.config.js present in {PATH}`

next
3. create an empty `tailwind.config.js` file at the root.
4. Restart ST, now you should see "LSP-tailwindcss - No tailwindcss package found in node_modules for path {PATH}. Make sure to install the tailwindcss npm package."

next
in terminal type:
5. `npm init -y` - that creates a package json file.
6. Install the dep with `npm install -D tailwindcss`
7. Restart ST, now you will see no errors.


NOTE:

I noticed a bug where the LSP-typescript plugin won't start if the LSP-tailwindcss plugin don't start.

1. I have LSP-typescript and LSP-tailwindcss installed.
2. If I create a `index.js` file in an empty folder.
3. The tailwindcss server wont be initialized(this is expected, because the folder doesn't meet the server requirements), but the LSP-typescript plugin won't be started as well(which is not expected) :)
