### PR TITLE
add support tailwind.config.cjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Provided through [Tailwind CSS IntelliSense](https://github.com/tailwindlabs/tai
 ### Installation
 
 * Install [LSP](https://packagecontrol.io/packages/LSP) and `LSP-tailwindcss` via Package Control.
-* In order for the extension to activate you must have [tailwindcss](https://tailwindcss.com/docs/installation) installed and a [Tailwind config file](https://tailwindcss.com/docs/installation#create-your-configuration-file) named `tailwind.config.js` in your workspace.
+* In order for the extension to activate you must have [tailwindcss](https://tailwindcss.com/docs/installation) installed and a [Tailwind config file](https://tailwindcss.com/docs/installation#create-your-configuration-file) named `tailwind.config.js` or `tailwind.config.cjs` in your workspace.
 * Restart Sublime.
 
 ### Configuration

--- a/plugin.py
+++ b/plugin.py
@@ -30,8 +30,9 @@ class LspTailwindcssPlugin(NpmClientHandler):
         if not workspace_folders:
             return "Requires a folder to start."
         path = workspace_folders[0].path
-        tailwind_config_file_path = os.path.join(path, 'tailwind.config.js')
-        if not os.path.exists(tailwind_config_file_path):
-            return "No tailwind.config.js present in {}".format(path)
+        tailwind_config_file_path_js = os.path.join(path, 'tailwind.config.js')
+        tailwind_config_file_path_cjs = os.path.join(path, 'tailwind.config.cjs')
+        if not os.path.exists(tailwind_config_file_path_js) and not os.path.exists(tailwind_config_file_path_cjs):
+            return "No tailwind.config.js or tailwind.config.cjs present in {}".format(path)
         return None
 


### PR DESCRIPTION
when working with svelte kit, they use `"type": "module"` in package.json. So, `tailwind.config.cjs` used instead of `tailwind.config.js`