### PR TITLE
remove is_allowed_to_start

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Provided through [Tailwind CSS IntelliSense](https://github.com/tailwindlabs/tai
 ### Installation
 
 * Install [LSP](https://packagecontrol.io/packages/LSP) and `LSP-tailwindcss` via Package Control.
-* In order for the extension to activate you must have a [Tailwind config file](https://tailwindcss.com/docs/installation#create-your-configuration-file) named `tailwind.config.js` in your workspace.
+* In order for LSP-tailwindcss to work, you must have a [Tailwind config file](https://tailwindcss.com/docs/installation#create-your-configuration-file) named `tailwind.config.js` in your workspace.
 * Restart Sublime.
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Provided through [Tailwind CSS IntelliSense](https://github.com/tailwindlabs/tai
 ### Installation
 
 * Install [LSP](https://packagecontrol.io/packages/LSP) and `LSP-tailwindcss` via Package Control.
-* In order for the extension to activate you must have [tailwindcss](https://tailwindcss.com/docs/installation) installed and a [Tailwind config file](https://tailwindcss.com/docs/installation#create-your-configuration-file) named `tailwind.config.js` in your workspace.
+* In order for the extension to activate you must have a [Tailwind config file](https://tailwindcss.com/docs/installation#create-your-configuration-file) named `tailwind.config.js` in your workspace.
 * Restart Sublime.
 
 ### Configuration

--- a/plugin.py
+++ b/plugin.py
@@ -1,12 +1,5 @@
-from LSP.plugin import ClientConfig
-from LSP.plugin import WorkspaceFolder
-from LSP.plugin.core.typing import List, Optional, Set
 from lsp_utils import NpmClientHandler
-import fnmatch
 import os
-import re
-import sublime
-import subprocess
 
 
 def plugin_loaded():
@@ -22,48 +15,3 @@ class LspTailwindcssPlugin(NpmClientHandler):
     server_directory = 'language-server'
     server_binary_path = os.path.join(server_directory, 'server', 'tailwindServer.js')
     skip_npm_install = True
-
-    @classmethod
-    def is_allowed_to_start(
-        cls,
-        window: sublime.Window,
-        initiating_view: Optional[sublime.View] = None,
-        workspace_folders: Optional[List[WorkspaceFolder]] = None,
-        configuration: Optional[ClientConfig] = None
-    ) -> Optional[str]:
-        if not workspace_folders:
-            return "Requires a folder to start."
-        # Config pattern is found here:
-        # https://github.com/tailwindlabs/tailwindcss-intellisense/blob/766a5d533dcb68640ce6b3270488f6701dd1173d/packages/vscode-tailwindcss/src/extension.ts#L40
-        config_file_pattern = r'^(tailwind|tailwind\.config)\.(js|cjs)$'
-        folder_exclude_patterns = set(
-            sublime.load_settings('Preferences.sublime-settings').get("folder_exclude_patterns", [])
-        )  # type: Set[str]
-        folder_exclude_patterns.add('node_modules')  # definitely exclude node_modules
-        config_file = find_file_in_workspace(config_file_pattern, workspace_folders[0].path, folder_exclude_patterns)
-        if not config_file:
-            return "No tailwind configuration file present in the workspace folder."
-        if not LspTailwindcssPlugin.is_tailwind_installed(config_file):
-            return "'tailwindcss' dependency is not installed in the workspace."
-        return None  # return None to start the session
-
-    @classmethod
-    def is_tailwind_installed(cls, file_path: str) -> bool:
-        server_directory_path = cls._server_directory_path()
-        resolve_module_script = os.path.join(server_directory_path, 'resolve_module.js')
-        command = [cls._node_bin(), resolve_module_script, file_path, 'tailwindcss']
-        tailwindcss_path = subprocess.check_output(command, universal_newlines=True)
-        return bool(tailwindcss_path)
-
-
-def find_file_in_workspace(file_pattern: str, root_folder: str,
-                           folder_exclude_patterns: Set[str] = None) -> Optional[str]:
-    for path, directories, files in os.walk(root_folder):
-        for folder_exclude_pattern in folder_exclude_patterns or []:
-            # skip ignored folders
-            directories[:] = [d for d in directories if not fnmatch.fnmatch(d, folder_exclude_pattern)]
-
-        for file in files:
-            if re.match(file_pattern, file):
-                return os.path.join(path, file)
-    return None


### PR DESCRIPTION
Let the server decide if it can run in the workspace or not.

This way the client extension will not prevent the server from running
in a workspace supported by the server.

Plus the server [now bundles the tailwindcss dependency](https://github.com/tailwindlabs/tailwindcss-intellisense/issues/448#issuecomment-1007643418),
That was one of the reasons why we had the check in the first place.
(because without that dependency the server didn't start)


closes #34 