### PR TITLE
Add support for Django template syntax

### DIFF
--- a/LSP-tailwindcss.sublime-settings
+++ b/LSP-tailwindcss.sublime-settings
@@ -26,12 +26,12 @@
 		"tailwindCSS.experimental.classRegex": [],
 	},
 	// ST4
-	"selector": "source.jsx | source.js.react | source.js | source.tsx | source.ts | source.css | source.scss | source.less | text.html.vue | text.html.svelte | text.html.basic | text.html.twig | text.blade | embedding.php | text.html.rails | text.html.erb | text.haml | text.jinja | text.html.elixir",
+	"selector": "source.jsx | source.js.react | source.js | source.tsx | source.ts | source.css | source.scss | source.less | text.html.vue | text.html.svelte | text.html.basic | text.html.twig | text.blade | embedding.php | text.html.rails | text.html.erb | text.haml | text.jinja | text.django | text.html.elixir",
 	// ST3
 	"languages": [
 		{
 			"languageId": "html",
-			"scopes": ["text.html.basic", "embedding.php", "text.blade", "text.html.twig", "text.jinja", "text.html.elixir"],
+			"scopes": ["text.html.basic", "embedding.php", "text.blade", "text.html.twig", "text.jinja", "text.django", "text.html.elixir"],
 			"syntaxes": [
 				"Packages/HTML/HTML.sublime-syntax",
 				"Packages/PHP/PHP.sublime-syntax",
@@ -40,6 +40,7 @@
 				"Packages/Twig/resources/syntax/Twig.sublime-syntax",
 				"Packages/Twig/resources/syntax/HTML (Twig).sublime-syntax",
 				"Packages/Jinja2/resources/syntax/Jinja.sublime-syntax",
+				"Packages/Django Syntax/Django HTML.sublime-syntax",
 				"Packages/Elixir/Syntaxes/HTML (EEx).tmLanguage"
 			]
 		},


### PR DESCRIPTION
I wondered why LSP wasn't working for my [Django](https://djangoproject.com) HTML templates. After I followed the steps outlined in https://github.com/sublimelsp/LSP-tailwindcss/issues/47 it worked. So here's a pull request so other people don't have to customize their configs to make it work.

This goes together with https://github.com/sublimelsp/LSP/pull/2121