### PR TITLE
Add support for rewritten Laravel Blade syntax

### DIFF
--- a/LSP-tailwindcss.sublime-settings
+++ b/LSP-tailwindcss.sublime-settings
@@ -26,7 +26,7 @@
 		"tailwindCSS.experimental.classRegex": [],
 	},
 	// ST4
-	"selector": "source.jsx | source.js.react | source.js | source.tsx | source.ts | source.css | source.scss | source.less | text.html.vue | text.html.svelte | text.html.basic | text.html.twig | text.blade | embedding.php | text.html.rails | text.html.erb | text.haml | text.jinja | text.django | text.html.elixir",
+	"selector": "source.jsx | source.js.react | source.js | source.tsx | source.ts | source.css | source.scss | source.less | text.html.vue | text.html.svelte | text.html.basic | text.html.twig | text.blade | text.html.blade | embedding.php | text.html.rails | text.html.erb | text.haml | text.jinja | text.django | text.html.elixir",
 	// ST3
 	"languages": [
 		{


### PR DESCRIPTION
This PR proposes to add `text.html.blade` to ST4 configuration in order to provide seemless update experience for a rewritten Laravel Blade syntax for ST4137+.

see: https://github.com/Medalink/laravel-blade/pull/195