### PR TITLE
Extend selector and sort values

### DIFF
--- a/LSP-tailwindcss.sublime-settings
+++ b/LSP-tailwindcss.sublime-settings
@@ -25,5 +25,5 @@
 		"tailwindCSS.lint.recommendedVariantOrder": "warning",
 		"tailwindCSS.experimental.classRegex": [],
 	},
-	"selector": "source.jsx | source.js.react | source.js | source.tsx | source.ts | source.css | source.scss | source.less | text.html.vue | text.html.svelte | text.html.basic | text.html.twig | text.blade | text.html.blade | embedding.php | text.html.rails | text.html.erb | text.haml | text.jinja | text.django | text.html.elixir | text.html.ngx | source.astro"
+	"selector": "embedding.php | source.astro | source.css | source.js | source.js.react | source.jsx | source.less | source.postcss | source.scss | source.ts | source.tsx | text.blade | text.django | text.haml | text.html.basic | text.html.blade | text.html.elixir | text.html.erb | text.html.jinja | text.html.ngx | text.html.rails | text.html.svelte | text.html.twig | text.html.vue | text.jinja | text.pug | text.slim"
 }


### PR DESCRIPTION
Resolves #65

This commit...

1. adds scopes:
   - source.postcss (for https://packagecontrol.io/packages/Syntax%20Highlighting%20for%20PostCSS)
   - text.html.jinja (for https://packagecontrol.io/packages/Jinja2 v2.0+)
   - text.pug (issue #65)
   - text.slim (for https://packagecontrol.io/packages/Ruby%20Slim)

2. sorts scopes alphabetically