### PR TITLE
Update language server to 0.14.1 (support TailwindCSS 4)

### DIFF
--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -1,13 +1,27 @@
 {
   "name": "sublime-tailwindcss",
   "version": "0.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@tailwindcss/language-server": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/language-server/-/language-server-0.0.25.tgz",
-      "integrity": "sha512-50zth1SuTo+auL7g0e5O+k2EBn/wk1Xn2Ya+NNiYruOjqOMFfyITKwlzVDzaHUEbmCwY3fhXDL3T41rH4xx2+Q=="
+  "packages": {
+    "": {
+      "name": "sublime-tailwindcss",
+      "version": "0.0.0",
+      "dependencies": {
+        "@tailwindcss/language-server": "0.14.1"
+      }
+    },
+    "node_modules/@tailwindcss/language-server": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/language-server/-/language-server-0.14.1.tgz",
+      "integrity": "sha512-n3z2rhl+n6be8EvqzTjZXSa5aSZBURaljYTpMva10/70aSKK8oCuS/ZJOr3//l00MfUoqCFIKGKGLkjs/LQRHQ==",
+      "license": "MIT",
+      "bin": {
+        "tailwindcss-language-server": "bin/tailwindcss-language-server"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     }
   }
 }

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -2,6 +2,6 @@
   "name": "sublime-tailwindcss",
   "version": "0.0.0",
   "dependencies": {
-    "@tailwindcss/language-server": "0.0.25"
+    "@tailwindcss/language-server": "0.14.1"
   }
 }


### PR DESCRIPTION
This commit...

1. updates packages-lock to newer scheme to keep dependabot working
2. updates langauge server to 0.14.1 (required for TailwindCSS 4)