### PR TITLE
Fix: use lockfile v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "LSP-tailwindcss",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Yarn fails to install dependencies when using `"lockfileVersion": 3`
Same issue and fix as https://github.com/sublimelsp/LSP-svelte/pull/157